### PR TITLE
Upgrade Ruby 2.6.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
+gem 'geometry-in-ruby', github: 'aurorasolar/geometry', branch: 'ruby-2.6.5'
+
 group :test do
-    gem 'rake'
+  gem 'rake'
 end

--- a/sketch.gemspec
+++ b/sketch.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'geometry', '~> 6.1'
+  s.add_dependency 'geometry-in-ruby'
+  s.add_development_dependency 'minitest'
 end

--- a/test/sketch.rb
+++ b/test/sketch.rb
@@ -110,7 +110,7 @@ describe Sketch do
     end
 
     describe "properties" do
-	subject { Sketch.new { add_circle [1,-2], 3; add_circle([-1,2], 3) } }
+	subject { Sketch.new { add_circle([1,-2], 3); add_circle([-1,2], 3) } }
 
 	it "must have a bounds rectangle" do
 	    subject.bounds.must_equal Rectangle.new(from:[-4,-5], to:[4,5])
@@ -172,7 +172,7 @@ describe Sketch do
     end
 
     describe "when the Sketch contains a group" do
-	subject { Sketch::Builder.new(Sketch.new).evaluate { translate [1,2] { circle [1,-2], 3; circle([-1,2], 3) } } }
+	subject { Sketch::Builder.new(Sketch.new).evaluate { translate([1,2]) { circle([1,-2], 3); circle([-1,2], 3) } } }
 
 	it "must have a max property" do
 	    subject.max.must_equal Point[5,7]

--- a/test/sketch/builder.rb
+++ b/test/sketch/builder.rb
@@ -108,7 +108,7 @@ describe Sketch::Builder do
 
 	describe "with a block" do
 	    before do
-		subject.group origin:[1,2,3] { circle diameter:1 }
+		subject.group(origin:[1,2,3]) { circle(diameter:1) }
 	    end
 
 	    it "must have a group element" do
@@ -123,7 +123,7 @@ describe Sketch::Builder do
 
     describe "when adding a translation" do
 	before do
-	    subject.translate [1,2] { circle diameter:1 }
+	    subject.translate([1,2]) { circle diameter:1 }
 	end
 
 	it "must have a group element" do
@@ -142,7 +142,7 @@ describe Sketch::Builder do
     describe "when adding a nested translation" do
 	before do
 	    subject.translate [1,2] do
-		translate [3,4] { circle diameter:2 }
+		translate([3,4]) { circle diameter:2 }
 	    end
 	end
 


### PR DESCRIPTION
https://aurorasolar.atlassian.net/browse/APP-1089

- Updates to newer Ruby syntax
- Uses our fork of `geometry-in-ruby`
- Using 2.6.5 branch for `geometry-in-ruby`
  - We can discuss deployment.  Was thinking we could deploy using branches so reverting could be as easy as using `master`.  Then when stable can merge PR's and use `master`